### PR TITLE
Fix frontend production build: Set NODE_ENV=production in Dockerfile

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /app
 COPY package*.json ./
 RUN npm ci
 
+ENV NODE_ENV=production
 COPY . .
 RUN npm run build
 


### PR DESCRIPTION
- Add NODE_ENV=production to frontend Dockerfile to ensure Vite uses production configuration
- Remove .env.production file to rely on Docker environment variables
- Docker compose already sets VITE_API_URL='' for relative URLs in production
- This resolves backend connection errors by using /api instead of localhost:3001